### PR TITLE
ツールチップがスクロールバーに被っていたため修正

### DIFF
--- a/src/__tests__/components/atoms/tooltip/__snapshots__/tooltip.test.tsx.snap
+++ b/src/__tests__/components/atoms/tooltip/__snapshots__/tooltip.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Tooltipのレンダリング確認 propsに設定した値でレンダリングされる。 1`] = `
 <span
-  class="sc-jTYCaT iKtWoH"
+  class="sc-jTYCaT oXIUP"
   data-testid="atoms-tt-wrap"
 >
   <span

--- a/src/components/atoms/tooltip/tooltip.tsx
+++ b/src/components/atoms/tooltip/tooltip.tsx
@@ -39,6 +39,7 @@ const Content = styled.span`
 const Wrap = styled.span`
   position: relative;
   cursor: pointer;
+  font-size: 11px;
   &:hover ${Content} {
     opacity: 1;
     visibility: visible;


### PR DESCRIPTION
# Description

ツールチップ表示をスクロールバーの上に表示

脆弱性一覧にて、対応状態をマウスオーバーした際、「要再診断」が見切れる場合があるため、スクロールバーの上に表示する。
→スクロールバー上に表示することが厳しかったため、サイズの調整を行なった。

Fixes # [1069](https://trello.com/c/ugfG1AeK)

## Type of change

関連性のないオプションを削除してください。

- [x] バグ修正（問題を修正する非破壊的な変更）

# How Has This Been Tested?


- [x] `yarn test`
- [ ] `stylebookで確認`

# Checklist:

- [x] 私のコードはこのプロジェクトのスタイルガイドラインに従っています
- [x] コードのセルフレビューを実行しました
- [ ] 特に理解しにくい領域で、自分のコードにコメントしました
- [ ] ドキュメントに対応する変更を加えました
- [x] 私の変更は新しい警告を生成しません
- [ ] 修正が効果的であること、または機能が機能することを証明するテストを追加しました
- [x] 新規および既存の単体テスト、機能テストは、ローカルで通ることを確認しました
- [x] 依存する変更はすべてマージされ、ダウンストリームモジュールで公開されています